### PR TITLE
Modified sentinelone-add-hash-to-blocklist command to support different scope

### DIFF
--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/README.md
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/README.md
@@ -21,7 +21,6 @@ If you are upgrading from a previous version of this integration, see [Breaking 
 | Define which Threats should be fetched. |  | False |
 | Fetch limit: The maximum number of threats or alerts to fetch |  | False |
 | Site IDs | Comma-separated list of site IDs to fetch incidents for. Leave blank to fetch all sites. | False |
-| Block Site IDs | Comma-separated list of site IDs for where hashes should be blocked. If left blank all hashes will be blocked globally. If filled out with site ids all hashes will be no longer be blocked globally, they will now be blocked in the scope of those sites. | False |
 | Trust any certificate (not secure) |  | False |
 | Use system proxy settings |  | False |
 | API Token (Deprecated) | Use the "API Token \(Recommended\)" parameter instead. | False |
@@ -1096,7 +1095,9 @@ Add a hash to the blocklist ("blacklist" in SentinelOne documentation). If the `
 ### sentinelone-add-hash-to-blocklist
 
 ***
-Add a hash to the global blocklist in SentinelOne.
+Add a hash to the blocklist in SentinelOne.  
+If a scope is provided (site, account, or group), the hash will be added to that specific scope.  
+If no scope is provided, the hash will be added to the global blocklist.
 
 #### Base Command
 
@@ -1106,10 +1107,13 @@ Add a hash to the global blocklist in SentinelOne.
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| sha1 | SHA1 hash to add to the global blocklist. | Optional |
+| sha1 | SHA1 hash to add to the blocklist. | Optional |
 | source | String describing the source of the block. Default is XSOAR. | Optional |
 | os_type | Type of operating system. Possible values are: windows, linux, macos. | Required |
 | description | Note stored in SentinelOne about the block. Default is Blocked from XSOAR. | Optional |
+| site_ids | Comma-separated string of site IDs to add the hash to. | Optional |
+| account_ids | Comma-separated string of account IDs to add the hash to. | Optional |
+| group_ids | Comma-separated string of group IDs to add the hash to. | Optional |
 
 #### Context Output
 
@@ -1121,7 +1125,9 @@ Add a hash to the global blocklist in SentinelOne.
 ### sentinelone-remove-hash-from-blocklist
 
 ***
-Remove a hash from the global blocklist in SentinelOne
+Remove a hash from the blocklist in SentinelOne.  
+If a scope is provided (site, account, or group), the hash will be removed from that specific scope.  
+If no scope is provided, the hash will be removed from the global blocklist.
 
 #### Base Command
 
@@ -1131,8 +1137,11 @@ Remove a hash from the global blocklist in SentinelOne
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| sha1 | SHA1 hash to remove from the global blocklist. | Optional |
+| sha1 | SHA1 hash to remove from the blocklist. | Optional |
 | os_type | Optional operating system type. If not supplied, will remove the SHA1 hash across all platforms. Possible values are: windows, macos, linux. | Optional |
+| site_ids | Comma-separated string of site IDs to remove the hash from. | Optional |
+| account_ids | Comma-separated string of account IDs to remove the hash from. | Optional |
+| group_ids | Comma-separated string of group IDs to remove the hash from. | Optional |
 
 #### Context Output
 

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -1688,7 +1688,8 @@ script:
     - description: SHA1 hash to add to the blocklist.
       name: sha1
       required: true
-    - description: String describing the source of the block.
+    - defaultValue: XSOAR
+      description: String describing the source of the block.
       name: source
     - auto: PREDEFINED
       name: os_type
@@ -1698,13 +1699,14 @@ script:
       - macos
       required: true
       description: Type of operating system.
-    - description: Note stored in SentinelOne about the block.
+    - defaultValue: Blocked from XSOAR
+      description: Note stored in SentinelOne about the block.
       name: description
-    - description: Comma-separated list of site IDs to scope the blocklist.
+    - description: Comma-separated string of site IDs to scope the blocklist.
       name: site_ids
-    - description: Comma-separated list of group IDs to scope the blocklist.
+    - description: Comma-separated string of group IDs to scope the blocklist.
       name: group_ids
-    - description: Comma-separated list of account IDs to scope the blocklist.
+    - description: Comma-separated string of account IDs to scope the blocklist.
       name: account_ids
     name: sentinelone-add-hash-to-blocklist
     description: Add a hash to the blocklist in SentinelOne. Supports scoping by site, group, or account.

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -1709,7 +1709,7 @@ script:
     - description: Comma-separated string of account IDs to scope the blocklist.
       name: account_ids
     name: sentinelone-add-hash-to-blocklist
-    description: Add a hash to the blocklist in SentinelOne. Supports scoping by site, group, or account.
+    description: Add a hash to the blocklist in SentinelOne. Supports scoping by site, group, or account. If Scope not provided, the block will be global.
     outputs:
     - contextPath: SentinelOne.AddHashToBlocklist.hash
       description: Hash of the file.

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -1685,10 +1685,10 @@ script:
       description: Name of the blocklist scope.
       type: String
   - arguments:
-    - description: SHA1 hash to add to the global blocklist.
+    - description: SHA1 hash to add to the blocklist.
       name: sha1
-    - defaultValue: XSOAR
-      description: String describing the source of the block.
+      required: true
+    - description: String describing the source of the block.
       name: source
     - auto: PREDEFINED
       name: os_type
@@ -1698,11 +1698,16 @@ script:
       - macos
       required: true
       description: Type of operating system.
-    - defaultValue: Blocked from XSOAR
-      description: Note stored in SentinelOne about the block.
+    - description: Note stored in SentinelOne about the block.
       name: description
-    description: Add a hash to the global blocklist in SentinelOne.
+    - description: Comma-separated list of site IDs to scope the blocklist.
+      name: site_ids
+    - description: Comma-separated list of group IDs to scope the blocklist.
+      name: group_ids
+    - description: Comma-separated list of account IDs to scope the blocklist.
+      name: account_ids
     name: sentinelone-add-hash-to-blocklist
+    description: Add a hash to the blocklist in SentinelOne. Supports scoping by site, group, or account.
     outputs:
     - contextPath: SentinelOne.AddHashToBlocklist.hash
       description: Hash of the file.

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2.yml
@@ -100,12 +100,6 @@ configuration:
   section: Collect
   additionalinfo: Comma-separated list of site IDs to fetch incidents for. Leave blank to fetch all sites.
   required: false
-- name: block_site_ids
-  display: Block Site IDs
-  type: 0
-  section: Collect
-  required: false
-  additionalinfo: Comma-separated list of site IDs for where hashes should be blocked. If left blank all hashes will be blocked globally. If filled out with site ids all hashes will be no longer be blocked globally, they will now be blocked in the scope of those sites.
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
@@ -1725,6 +1719,12 @@ script:
       - windows
       - macos
       - linux
+    - description: Comma-separated string of site IDs to scope the blocklist.
+      name: site_ids
+    - description: Comma-separated string of group IDs to scope the blocklist.
+      name: group_ids
+    - description: Comma-separated string of account IDs to scope the blocklist.
+      name: account_ids
     description: Remove a hash from the global blocklist in SentinelOne.
     name: sentinelone-remove-hash-from-blocklist
     outputs:

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
@@ -276,7 +276,8 @@ def test_remove_hash_from_blocklist_multiple_site_scope(mocker, requests_mock):
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&siteIds=siteX,siteY&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains=" + sha1
+        "?tenant=False&siteIds=2134673222384,2144637475766&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
     requests_mock.get(url, json=raw_blockist_response)
@@ -288,7 +289,9 @@ def test_remove_hash_from_blocklist_multiple_site_scope(mocker, requests_mock):
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "site_ids": "siteX,siteY"})
+    mocker.patch.object(
+        demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "site_ids": "2134673222384,2144637475766"}
+    )
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -311,7 +314,8 @@ def test_remove_hash_from_blocklist_single_site_scope(mocker, requests_mock):
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&siteIds=siteX&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains=" + sha1
+        "?tenant=False&siteIds=2134673222384&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
     requests_mock.get(url, json=raw_blockist_response)
@@ -323,7 +327,7 @@ def test_remove_hash_from_blocklist_single_site_scope(mocker, requests_mock):
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "site_ids": "siteX"})
+    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "site_ids": "2134673222384"})
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -346,7 +350,7 @@ def test_remove_hash_from_blocklist_multiple_group_scope(mocker, requests_mock):
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&groupIds=groupX,groupY&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        "?tenant=False&groupIds=3327473684756,3365722136475&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
         + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
@@ -359,7 +363,9 @@ def test_remove_hash_from_blocklist_multiple_group_scope(mocker, requests_mock):
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "group_ids": "groupX,groupY"})
+    mocker.patch.object(
+        demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "group_ids": "3327473684756,3365722136475"}
+    )
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -382,7 +388,8 @@ def test_remove_hash_from_blocklist_single_group_scope(mocker, requests_mock):
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&groupIds=groupX&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains=" + sha1
+        "?tenant=False&groupIds=3327473684756&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
     requests_mock.get(url, json=raw_blockist_response)
@@ -394,7 +401,7 @@ def test_remove_hash_from_blocklist_single_group_scope(mocker, requests_mock):
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "group_ids": "groupX"})
+    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "group_ids": "3327473684756"})
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -417,7 +424,7 @@ def test_remove_hash_from_blocklist_multiple_account_scope(mocker, requests_mock
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&accountIds=accountX,accountY&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        "?tenant=False&accountIds=4437562837465,4467983212746&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
         + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
@@ -430,7 +437,9 @@ def test_remove_hash_from_blocklist_multiple_account_scope(mocker, requests_mock
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "account_ids": "accountX,accountY"})
+    mocker.patch.object(
+        demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "account_ids": "4437562837465,4467983212746"}
+    )
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -453,7 +462,8 @@ def test_remove_hash_from_blocklist_single_account_scope(mocker, requests_mock):
     sha1 = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
     url = (
         "https://usea1.sentinelone.net/web/api/v2.1/restrictions"
-        "?tenant=False&accountIds=accountX&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains=" + sha1
+        "?tenant=False&accountIds=4437562837465&skip=0&limit=20&osTypes=WINDOWS&sortBy=updatedAt&sortOrder=asc&value__contains="
+        + sha1
     )
     raw_blockist_response = util_load_json("test_data/remove_hash_from_blocklist.json")
     requests_mock.get(url, json=raw_blockist_response)
@@ -465,7 +475,7 @@ def test_remove_hash_from_blocklist_single_account_scope(mocker, requests_mock):
         return_value={"token": "token", "url": "https://usea1.sentinelone.net", "api_version": "2.1", "fetch_threat_rank": "4"},
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-remove-hash-from-blocklist")
-    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "account_ids": "accountX"})
+    mocker.patch.object(demisto, "args", return_value={"sha1": sha1, "os_type": "WINDOWS", "account_ids": "4437562837465"})
 
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -496,7 +506,7 @@ def test_add_hash_to_blocklist_args_multiple_site_ids(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "site_ids": "siteX,siteY"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "site_ids": "2134673222384,2144637475766"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -504,7 +514,7 @@ def test_add_hash_to_blocklist_args_multiple_site_ids(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("siteIds") == "siteX,siteY"
+    assert request_filter.get("siteIds") == "2134673222384,2144637475766"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -513,8 +523,8 @@ def test_add_hash_to_blocklist_args_multiple_site_ids(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to site: siteX,siteY blocklist"
-    assert outputs.get("site_ids") == "siteX,siteY"
+    assert outputs["status"] == "Added to site: 2134673222384,2144637475766 blocklist"
+    assert outputs.get("site_ids") == "2134673222384,2144637475766"
 
 
 def test_add_hash_to_blocklist_args_single_site_id(mocker, requests_mock):
@@ -535,7 +545,7 @@ def test_add_hash_to_blocklist_args_single_site_id(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "site_ids": "siteX"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "site_ids": "2134673222384"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -543,7 +553,7 @@ def test_add_hash_to_blocklist_args_single_site_id(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("siteIds") == "siteX"
+    assert request_filter.get("siteIds") == "2134673222384"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -552,8 +562,8 @@ def test_add_hash_to_blocklist_args_single_site_id(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to site: siteX blocklist"
-    assert outputs.get("site_ids") == "siteX"
+    assert outputs["status"] == "Added to site: 2134673222384 blocklist"
+    assert outputs.get("site_ids") == "2134673222384"
 
 
 def test_add_hash_to_blocklist_args_multiple_group_ids(mocker, requests_mock):
@@ -574,7 +584,7 @@ def test_add_hash_to_blocklist_args_multiple_group_ids(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "group_ids": "group1,group2"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "group_ids": "3327473684756,3365722136475"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -582,7 +592,7 @@ def test_add_hash_to_blocklist_args_multiple_group_ids(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("groupIds") == "group1,group2"
+    assert request_filter.get("groupIds") == "3327473684756,3365722136475"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -591,8 +601,8 @@ def test_add_hash_to_blocklist_args_multiple_group_ids(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to group: group1,group2 blocklist"
-    assert outputs.get("group_ids") == "group1,group2"
+    assert outputs["status"] == "Added to group: 3327473684756,3365722136475 blocklist"
+    assert outputs.get("group_ids") == "3327473684756,3365722136475"
 
 
 def test_add_hash_to_blocklist_args_single_group_id(mocker, requests_mock):
@@ -613,7 +623,7 @@ def test_add_hash_to_blocklist_args_single_group_id(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "group_ids": "group1"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "group_ids": "3327473684756"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -621,7 +631,7 @@ def test_add_hash_to_blocklist_args_single_group_id(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("groupIds") == "group1"
+    assert request_filter.get("groupIds") == "3327473684756"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -630,8 +640,8 @@ def test_add_hash_to_blocklist_args_single_group_id(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to group: group1 blocklist"
-    assert outputs.get("group_ids") == "group1"
+    assert outputs["status"] == "Added to group: 3327473684756 blocklist"
+    assert outputs.get("group_ids") == "3327473684756"
 
 
 def test_add_hash_to_blocklist_args_multiple_account_ids(mocker, requests_mock):
@@ -652,7 +662,7 @@ def test_add_hash_to_blocklist_args_multiple_account_ids(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "account_ids": "acc123,acc456"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "account_ids": "4437562837465,4467983212746"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -660,7 +670,7 @@ def test_add_hash_to_blocklist_args_multiple_account_ids(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("accountIds") == "acc123,acc456"
+    assert request_filter.get("accountIds") == "4437562837465,4467983212746"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -669,8 +679,8 @@ def test_add_hash_to_blocklist_args_multiple_account_ids(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to account: acc123,acc456 blocklist"
-    assert outputs.get("account_ids") == "acc123,acc456"
+    assert outputs["status"] == "Added to account: 4437562837465,4467983212746 blocklist"
+    assert outputs.get("account_ids") == "4437562837465,4467983212746"
 
 
 def test_add_hash_to_blocklist_args_single_account_id(mocker, requests_mock):
@@ -691,7 +701,7 @@ def test_add_hash_to_blocklist_args_single_account_id(mocker, requests_mock):
         },
     )
     mocker.patch.object(demisto, "command", return_value="sentinelone-add-hash-to-blocklist")
-    args = {"sha1": sha1, "os_type": "WINDOWS", "account_ids": "acc123"}
+    args = {"sha1": sha1, "os_type": "WINDOWS", "account_ids": "4437562837465"}
     mocker.patch.object(demisto, "args", return_value=args)
     mock_return_results = mocker.patch.object(sentinelone_v2, "return_results")
 
@@ -699,7 +709,7 @@ def test_add_hash_to_blocklist_args_single_account_id(mocker, requests_mock):
 
     request_body = requests_mock.last_request.json()
     request_filter = request_body.get("filter")
-    assert request_filter.get("accountIds") == "acc123"
+    assert request_filter.get("accountIds") == "4437562837465"
 
     call = mock_return_results.call_args_list
     assert call, "return_results not called"
@@ -708,8 +718,8 @@ def test_add_hash_to_blocklist_args_single_account_id(mocker, requests_mock):
     outputs = result.outputs
 
     assert outputs["hash"] == sha1
-    assert outputs["status"] == "Added to account: acc123 blocklist"
-    assert outputs.get("account_ids") == "acc123"
+    assert outputs["status"] == "Added to account: 4437562837465 blocklist"
+    assert outputs.get("account_ids") == "4437562837465"
 
 
 def test_add_hash_to_blocklist_global_fallback(mocker, requests_mock):

--- a/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
+++ b/Packs/SentinelOne/Integrations/SentinelOne-V2/SentinelOne-V2_test.py
@@ -802,6 +802,7 @@ def test_get_power_query_results(mocker, requests_mock):
         demisto,
         "args",
         return_value={
+            "query_id": "pq123456789",
             "from_date": "2024-08-20T04:49:26.257525Z",
             "to_date": "2024-08-21T04:49:26.257525Z",
             "query": "event.time = * | columns eventTime = event.time, agentUuid = agent.uuid, siteId = site.id",


### PR DESCRIPTION
**Enhancement:**  
Added support for scoping blocklist additions in the SentinelOne XSOAR integration.

**Details:**
- Updated the `sentinelone-add-hash-to-blocklist` command to accept `site_ids`, `group_ids`, and `account_ids` as arguments.
- Enhanced the integration logic to allow adding hashes to the blocklist at the site, group, account, or global scope, as supported by the SentinelOne API.
- Updated the command handler and client methods to handle all three scope filters.
- Tested the changes to ensure correct behavior for all supported scopes.

**Impact:**  
Users can now specify the desired scope when adding a hash to the blocklist, resolving previous limitations and permission issues in shared console environments.

**Closes:**  
- Feature request for scoped blocklist support 